### PR TITLE
change from mc pos control to ts pos control

### DIFF
--- a/posix-configs/SITL/init/lpe/hummingbird
+++ b/posix-configs/SITL/init/lpe/hummingbird
@@ -85,7 +85,7 @@ land_detector start vtol
 navigator start
 attitude_estimator_q start
 local_position_estimator start
-mc_pos_control start
+ts_pos_control start
 mixer load /dev/pwm_output0 ROMFS/px4fmu_common/mixers/caipirinha_vtol.main.mix
 mavlink start -u 14556 -r 20000 -m config -o 14540 -v
 logger start -b 24 -t

--- a/src/modules/ts_pos_control/ts_pos_control_main.cpp
+++ b/src/modules/ts_pos_control/ts_pos_control_main.cpp
@@ -1953,7 +1953,7 @@ TailsitterPositionControl::control_position(float dt)
 			l = pow(l,0.5f);
 			float psi = asin(thrust_sp(0) / l);
 			psi = _att_sp.yaw_body;
-			math::Vector<3> y_C(sin(psi), cos(psi), 0.0f);
+			math::Vector<3> y_C(-1*sin(psi), cos(psi), 0.0f);
 			if(!_pos_sp_triplet.current.yaw_valid || std::isnan(psi)){
 				y_C.zero();
 				y_C(1) = 1.0f;


### PR DESCRIPTION
We weren't simulating the position controller. Also, without this, messages to /mavros/setpoint_position/local will ignore the yaw setpoint.

Currently what will happen is that it will launch and then rotate 180 degrees.

